### PR TITLE
Write Western Digital as two separate words

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,18 +336,18 @@
 
 			/* Companies/orgnaisations */
 			var organisations = {
-				arm: {			title: "ARM",		url: "https://www.arm.com/"		},
-				axis: {			title: "Axis",		url: "https://www.axis.com/"		},
-				//canonical: {		title: "Canonical",	url: "https://www.canonical.com/"	},
-				cnexlabs: {		title: "CNEX Labs",	url: "https://www.cnexlabs.com/"	},
-				ericsson: {		title: "Ericsson",	url: "https://www.ericsson.com/"	},
-				intel_otc: {		title: "intel",		url: "https://01.org/"			},
-				linaro: {		title: "Linaro",	url: "https://www.linaro.org/"		},
-				lth: {			title: "LTH",		url: "http://www.lth.se/"		},
-				prevas: {		title: "Prevas",	url: "http://www.prevas.com/"		},
-				itu: {			title: "ITU",		url: "https://www.itu.dk/"		},
-				westerndigital: {	title: 'Westerndigital',url: "https://www.wdc.com/"		},
-				samsung_semi: {		title: "Samsung", url: "https://www.samsung.com/semiconductor/" }
+				arm: {			title: "ARM",			url: "https://www.arm.com/"			},
+				axis: {			title: "Axis",			url: "https://www.axis.com/"			},
+				//canonical: {		title: "Canonical",		url: "https://www.canonical.com/"		},
+				cnexlabs: {		title: "CNEX Labs",		url: "https://www.cnexlabs.com/"		},
+				ericsson: {		title: "Ericsson",		url: "https://www.ericsson.com/"		},
+				intel_otc: {		title: "intel",			url: "https://01.org/"				},
+				linaro: {		title: "Linaro",		url: "https://www.linaro.org/"			},
+				lth: {			title: "LTH",			url: "http://www.lth.se/"			},
+				prevas: {		title: "Prevas",		url: "http://www.prevas.com/"			},
+				itu: {			title: "ITU",			url: "https://www.itu.dk/"			},
+				westerndigital: {	title: 'Western Digital',	url: "https://www.wdc.com/"			},
+				samsung_semi: {		title: "Samsung",		url: "https://www.samsung.com/semiconductor/"	}
 			}
 			/* presenters/crew with website/email */
 			var presenters = {


### PR DESCRIPTION
Since this organization name was too long, also had to add a new level of
indentation.